### PR TITLE
Corrigido um aviso de "this statement may fall through" 

### DIFF
--- a/VenusDrv.c
+++ b/VenusDrv.c
@@ -1400,7 +1400,7 @@ static int hfdu04_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
         {
             bulk_flag = 1; /* bulk write mode is set */
         }
-
+    break;
     case _IOC_NR(EZUSB_BULK_READ):
         if (dev->bcdDevice < 0x2000)
         {


### PR DESCRIPTION
Corrigido um aviso de "this statement may fall through"  VenusDrv.c. O aviso ocorria no switch-case. Adicionei um break para garantir que o fluxo seja controlado corretamente e o aviso não seja mais gerado.
Após realização dessa correção foi possível compilar o Driver usando o Ubuntu 20.04, kernel versão 5.4.0-177-generic e 5.4.0-42-generic.